### PR TITLE
Omit undefined arguments in query string

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -68,9 +68,8 @@
    * @param {string} operator
    * @param {string} key
    * @param {string} modifier
-   * @param {bool} skipEmptyArgs
    */
-  UrlTemplate.prototype.getValues = function (context, operator, key, modifier, skipEmptyArgs) {
+  UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
     var value = context[key],
         result = [];
 
@@ -113,18 +112,16 @@
           }
 
           if (this.isKeyOperator(operator)) {
-            if(tmp.length > 0 || !skipEmptyArgs) {
-              result.push(encodeURIComponent(key) + '=' + tmp.join(','));
-            }
+            result.push(encodeURIComponent(key) + '=' + tmp.join(','));
           } else if (tmp.length !== 0) {
             result.push(tmp.join(','));
           }
         }
       }
-    } else if(!skipEmptyArgs) {
+    } else {
       if (operator === ';') {
         result.push(encodeURIComponent(key));
-      } else if (operator === '&' || operator === '?') {
+      } else if (value === '' && (operator === '&' || operator === '?')) {
         result.push(encodeURIComponent(key) + '=');
       } else if (value === '') {
         result.push('');
@@ -135,10 +132,9 @@
 
   /**
    * @param {string} template
-   * @param {bool} skipEmptyArgs
    * @return {function(Object):string}
    */
-  UrlTemplate.prototype.parse = function (template, skipEmptyArgs) {
+  UrlTemplate.prototype.parse = function (template) {
     var that = this;
     var operators = ['+', '#', '.', '/', ';', '?', '&'];
 
@@ -156,7 +152,7 @@
 
             expression.split(/,/g).forEach(function (variable) {
               var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push.apply(values, that.getValues(context, operator, tmp[1], tmp[2] || tmp[3], !!skipEmptyArgs));
+              values.push.apply(values, that.getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
             });
 
             if (operator && operator !== '+') {

--- a/test/url-template-test.js
+++ b/test/url-template-test.js
@@ -8,9 +8,9 @@ if (typeof require !== 'undefined') {
   expect = window.expect;
 }
 
-function createTestContext(c, skip) {
+function createTestContext(c) {
   return function (t, r) {
-    expect(template.parse(t, skip).expand(c)).to.eql(r);
+    expect(template.parse(t).expand(c)).to.eql(r);
   };
 }
 
@@ -344,7 +344,7 @@ describe('uri-template', function () {
       assert('{keys:1}', 'foo,bar');
     });
   });
-  describe('Skipping empty arguments', function () {
+  describe('Skipping undefined arguments', function () {
     var assert = createTestContext({
           'var': 'value',
           'number': 2133,
@@ -352,7 +352,7 @@ describe('uri-template', function () {
           'emptylist': [],
           'emptyobject': {},
           'undefinedlistitem': [1,,2],
-        }, true);
+        });
     it('variable undefined list item', function () {
       assert('{undefinedlistitem}', '1,2');
       assert('{undefinedlistitem*}', '1,2');
@@ -362,21 +362,10 @@ describe('uri-template', function () {
     it('query with empty/undefined arguments', function () {
       assert('{?var,number}', '?var=value&number=2133');
       assert('{?undef}', '');
-      assert('{?empty}', '');
-      assert('{?emptylist}', '');
-      assert('{?emptyobject}', '');
-      assert('{?undef,var,empty,emptylist,emptyobject}', '?var=value');
-    });
-
-    it('variable empty string', function () {
-      assert('{emptystring}', '');
-      assert('{+emptystring}', '');
-      assert('{#emptystring}', '');
-      assert('{.emptystring}', '');
-      assert('{/emptystring}', '');
-      assert('{;emptystring}', '');
-      assert('{?emptystring}', '');
-      assert('{&emptystring}', '');
+      assert('{?emptystring}', '?emptystring=');
+      assert('{?emptylist}', '?emptylist=');
+      assert('{?emptyobject}', '?emptyobject=');
+      assert('{?undef,var,emptystring}', '?var=value&emptystring=');
     });
   });
 });


### PR DESCRIPTION
The specification states that:

```
 http://www.example.com/foo{?query,number} 
```

would expand to 

```
 http://www.example.com/foo?query=mycelium&number=100
```

   Alternatively, if 'query' is undefined, then the expansion would be

```
 http://www.example.com/foo?number=100
```

   or if both variables are undefined, then it would be

```
 http://www.example.com/foo
```

Current implementation behaves like this:

``` javascript
template.parse('/endpoint{?page,per_page}').expand({}) == '/endpoint?page=&per_page='
```

With this PR the url is a bit cleaner:

``` javascript
template.parse('/endpoint{?page,per_page}').expand({}) == '/endpoint'
```
