### PR TITLE
Allow a context to contain its own template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ If you want to use it in a browser, copy `lib/url-template.js` into your project
       id: 42
     });
 
+### Config files
+
+A common pattern in config files is to have a bunch of configuration settings and a URL template that are all used together. For example, a YAML file might contain:
+
+```yaml
+database:
+  path:
+    driver: postgres
+    database: mydb
+    username: postgres
+    password: blah
+    host: localhost
+    _: {driver}://{username}:{password}@{host}/{database}
+```
+
+If a template object is created with no initial URI template then the `expand` method will look for a template in the context:
+
+    var template = require('url-template');
+
+    ...
+
+    var emailUrl = template.parse();
+
+    // Returns '/user@domain/test/42'
+    emailUrl.expand({
+      email: 'user@domain',
+      folder: 'test',
+      id: 42,
+      _: '/{email}/{folder}/{id}'
+    });
+
 ## A note on error handling and reporting
 
 The RFC states that errors in the templates could optionally be handled and reported to the user. This implementation takes a slightly different approach in that it tries to do a best effort template expansion and leaves erroneous expressions in the returned URI instead of throwing errors. So for example, the incorrect expression `{unclosed` will return `{unclosed` as output. The leaves incorrect URLs to be handled by your URL library of choice.

--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -140,6 +140,13 @@
 
     return {
       expand: function (context) {
+        /**
+         * If no template was provided then see if the context itself contains one:
+         */
+
+        if (!template && '_' in context){
+          template = context['_'];
+        }
         return template.replace(/\{([^\{\}]+)\}|([^\{\}]+)/g, function (_, expression, literal) {
           if (expression) {
             var operator = null,

--- a/test/url-template-test.js
+++ b/test/url-template-test.js
@@ -368,4 +368,17 @@ describe('uri-template', function () {
       assert('{?undef,var,emptystring}', '?var=value&emptystring=');
     });
   });
+  describe('Template in context', function () {
+    var assert = createTestContext({
+          'driver': 'postgres',
+          'database': 'mydb',
+          'username': 'postgres',
+          'password': 'blah',
+          'host': 'localhost',
+          '_': '{driver}://{username}:{password}@{host}/{database}'
+        });
+    it('create Postgres URL', function () {
+      assert(null, 'postgres://postgres:blah@localhost/mydb');
+    });
+  });
 });


### PR DESCRIPTION
Hi there.

I had my own module which wrapped `url-template` in order to allow me to create config settings that combine settings and a URI template.

I was just about to push it to NPM so that I can use it in a couple of other projects when I realised that if I were to add this one statement to `url-template` I wouldn't need any wrapper code at all.

...hence the pull request.

Thanks for a very useful module, by the way.

Mark
