### PR TITLE
Add 'extract' method to retrieve placeholders and make it possible to interpolate on-demand.

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -184,6 +184,24 @@
             return that.encodeReserved(literal);
           }
         });
+      },
+
+      extract: function () {
+		var variables = {};
+		template.replace(/\{([^\{\}]+)\}|([^\{\}]+)/g, function (_, expression) {
+          if (expression) {
+
+            if (operators.indexOf(expression.charAt(0)) !== -1) {
+              expression = expression.substr(1);
+            }
+
+            expression.split(/,/g).forEach(function (variable) {
+				variables[variable] = '';
+            });
+
+          }
+        });
+		return variables;
       }
     };
   };


### PR DESCRIPTION
The method returns an object with placeholders as keys and empty
strings as values. This object can be filled with required values and
be used in 'expand' method.