### PR TITLE
only publish production files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "scripts": {
     "test": "mocha --reporter spec"
-  }
+  },
+  "files": [
+    "lib" 
+  ]
 }


### PR DESCRIPTION
This will reduce the payload by 90% when installing `url-template`

![image](https://user-images.githubusercontent.com/39992/48323975-adbd4780-e5e3-11e8-83b9-86e0fbf6bedf.png)


This is a follow up for https://github.com/octokit/rest.js/issues/824