### PR TITLE
Change license spdx from BSD to BSD-3-Clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mocha": "=1.6.0",
     "expect.js": "=0.2.0"
   },
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/bramstein/url-template.git"


### PR DESCRIPTION
The "BSD" spdx refers to the original, controversial 4-clause BSD
license. At a glance, it looks like the license file in this repo is
actually using the 3-clause license, which has a spdx of "BSD-3-Clause".

https://spdx.org/licenses/BSD-3-Clause.html