### PR TITLE
Stop advertising Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ For use with Node.js you can install it through npm:
 $ npm install url-template
 ```
 
-If you want to use it in a browser, copy `lib/url-template.js` into your project and use the global `urltemplate` instance. Alternatively you can use [Bower](http://bower.io/) to install this package:
-
-```sh
-$ bower install url-template
-```
+If you want to use it in a browser, copy `lib/url-template.js` into your project and use the global `urltemplate` instance.
 
 ## Example
 


### PR DESCRIPTION
Stops advertising Bower as it has been in maintenance mode for quite some time, and is actively advertising using alternate installation methods on [their own site](https://bower.io/blog/2017/how-to-migrate-away-from-bower/).