### PR TITLE
Change distributed code to use ECMAScript modules

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -1,192 +1,182 @@
-(function (root, factory) {
-    if (typeof exports === 'object') {
-        module.exports = factory();
-    } else if (typeof define === 'function' && define.amd) {
-        define([], factory);
-    } else {
-        root.urltemplate = factory();
-    }
-}(this, function () {
-  /**
-   * @constructor
-   */
-  function UrlTemplate() {
-  }
+/**
+ * @constructor
+ */
+function UrlTemplate() {
+}
 
-  /**
-   * @private
-   * @param {string} str
-   * @return {string}
-   */
-  UrlTemplate.prototype.encodeReserved = function (str) {
-    return str.split(/(%[0-9A-Fa-f]{2})/g).map(function (part) {
-      if (!/%[0-9A-Fa-f]/.test(part)) {
-        part = encodeURI(part).replace(/%5B/g, '[').replace(/%5D/g, ']');
+/**
+ * @private
+ * @param {string} str
+ * @return {string}
+ */
+UrlTemplate.prototype.encodeReserved = function (str) {
+  return str.split(/(%[0-9A-Fa-f]{2})/g).map(function (part) {
+    if (!/%[0-9A-Fa-f]/.test(part)) {
+      part = encodeURI(part).replace(/%5B/g, '[').replace(/%5D/g, ']');
+    }
+    return part;
+  }).join('');
+};
+
+/**
+ * @private
+ * @param {string} str
+ * @return {string}
+ */
+UrlTemplate.prototype.encodeUnreserved = function (str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+  });
+}
+
+/**
+ * @private
+ * @param {string} operator
+ * @param {string} value
+ * @param {string} key
+ * @return {string}
+ */
+UrlTemplate.prototype.encodeValue = function (operator, value, key) {
+  value = (operator === '+' || operator === '#') ? this.encodeReserved(value) : this.encodeUnreserved(value);
+
+  if (key) {
+    return this.encodeUnreserved(key) + '=' + value;
+  } else {
+    return value;
+  }
+};
+
+/**
+ * @private
+ * @param {*} value
+ * @return {boolean}
+ */
+UrlTemplate.prototype.isDefined = function (value) {
+  return value !== undefined && value !== null;
+};
+
+/**
+ * @private
+ * @param {string}
+ * @return {boolean}
+ */
+UrlTemplate.prototype.isKeyOperator = function (operator) {
+  return operator === ';' || operator === '&' || operator === '?';
+};
+
+/**
+ * @private
+ * @param {Object} context
+ * @param {string} operator
+ * @param {string} key
+ * @param {string} modifier
+ */
+UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
+  var value = context[key],
+      result = [];
+
+  if (this.isDefined(value) && value !== '') {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      value = value.toString();
+
+      if (modifier && modifier !== '*') {
+        value = value.substring(0, parseInt(modifier, 10));
       }
-      return part;
-    }).join('');
-  };
 
-  /**
-   * @private
-   * @param {string} str
-   * @return {string}
-   */
-  UrlTemplate.prototype.encodeUnreserved = function (str) {
-    return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
-      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
-    });
-  }
-
-  /**
-   * @private
-   * @param {string} operator
-   * @param {string} value
-   * @param {string} key
-   * @return {string}
-   */
-  UrlTemplate.prototype.encodeValue = function (operator, value, key) {
-    value = (operator === '+' || operator === '#') ? this.encodeReserved(value) : this.encodeUnreserved(value);
-
-    if (key) {
-      return this.encodeUnreserved(key) + '=' + value;
+      result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
     } else {
-      return value;
-    }
-  };
+      if (modifier === '*') {
+        if (Array.isArray(value)) {
+          value.filter(this.isDefined).forEach(function (value) {
+            result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
+          }, this);
+        } else {
+          Object.keys(value).forEach(function (k) {
+            if (this.isDefined(value[k])) {
+              result.push(this.encodeValue(operator, value[k], k));
+            }
+          }, this);
+        }
+      } else {
+        var tmp = [];
 
-  /**
-   * @private
-   * @param {*} value
-   * @return {boolean}
-   */
-  UrlTemplate.prototype.isDefined = function (value) {
-    return value !== undefined && value !== null;
-  };
-
-  /**
-   * @private
-   * @param {string}
-   * @return {boolean}
-   */
-  UrlTemplate.prototype.isKeyOperator = function (operator) {
-    return operator === ';' || operator === '&' || operator === '?';
-  };
-
-  /**
-   * @private
-   * @param {Object} context
-   * @param {string} operator
-   * @param {string} key
-   * @param {string} modifier
-   */
-  UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
-    var value = context[key],
-        result = [];
-
-    if (this.isDefined(value) && value !== '') {
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        value = value.toString();
-
-        if (modifier && modifier !== '*') {
-          value = value.substring(0, parseInt(modifier, 10));
+        if (Array.isArray(value)) {
+          value.filter(this.isDefined).forEach(function (value) {
+            tmp.push(this.encodeValue(operator, value));
+          }, this);
+        } else {
+          Object.keys(value).forEach(function (k) {
+            if (this.isDefined(value[k])) {
+              tmp.push(this.encodeUnreserved(k));
+              tmp.push(this.encodeValue(operator, value[k].toString()));
+            }
+          }, this);
         }
 
-        result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
-      } else {
-        if (modifier === '*') {
-          if (Array.isArray(value)) {
-            value.filter(this.isDefined).forEach(function (value) {
-              result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
-            }, this);
+        if (this.isKeyOperator(operator)) {
+          result.push(this.encodeUnreserved(key) + '=' + tmp.join(','));
+        } else if (tmp.length !== 0) {
+          result.push(tmp.join(','));
+        }
+      }
+    }
+  } else {
+    if (operator === ';') {
+      if (this.isDefined(value)) {
+        result.push(this.encodeUnreserved(key));
+      }
+    } else if (value === '' && (operator === '&' || operator === '?')) {
+      result.push(this.encodeUnreserved(key) + '=');
+    } else if (value === '') {
+      result.push('');
+    }
+  }
+  return result;
+};
+
+/**
+ * @param {string} template
+ * @return {function(Object):string}
+ */
+UrlTemplate.prototype.parse = function (template) {
+  var that = this;
+  var operators = ['+', '#', '.', '/', ';', '?', '&'];
+
+  return {
+    expand: function (context) {
+      return template.replace(/\{([^\{\}]+)\}|([^\{\}]+)/g, function (_, expression, literal) {
+        if (expression) {
+          var operator = null,
+              values = [];
+
+          if (operators.indexOf(expression.charAt(0)) !== -1) {
+            operator = expression.charAt(0);
+            expression = expression.substr(1);
+          }
+
+          expression.split(/,/g).forEach(function (variable) {
+            var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
+            values.push.apply(values, that.getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+          });
+
+          if (operator && operator !== '+') {
+            var separator = ',';
+
+            if (operator === '?') {
+              separator = '&';
+            } else if (operator !== '#') {
+              separator = operator;
+            }
+            return (values.length !== 0 ? operator : '') + values.join(separator);
           } else {
-            Object.keys(value).forEach(function (k) {
-              if (this.isDefined(value[k])) {
-                result.push(this.encodeValue(operator, value[k], k));
-              }
-            }, this);
+            return values.join(',');
           }
         } else {
-          var tmp = [];
-
-          if (Array.isArray(value)) {
-            value.filter(this.isDefined).forEach(function (value) {
-              tmp.push(this.encodeValue(operator, value));
-            }, this);
-          } else {
-            Object.keys(value).forEach(function (k) {
-              if (this.isDefined(value[k])) {
-                tmp.push(this.encodeUnreserved(k));
-                tmp.push(this.encodeValue(operator, value[k].toString()));
-              }
-            }, this);
-          }
-
-          if (this.isKeyOperator(operator)) {
-            result.push(this.encodeUnreserved(key) + '=' + tmp.join(','));
-          } else if (tmp.length !== 0) {
-            result.push(tmp.join(','));
-          }
+          return that.encodeReserved(literal);
         }
-      }
-    } else {
-      if (operator === ';') {
-        if (this.isDefined(value)) {
-          result.push(this.encodeUnreserved(key));
-        }
-      } else if (value === '' && (operator === '&' || operator === '?')) {
-        result.push(this.encodeUnreserved(key) + '=');
-      } else if (value === '') {
-        result.push('');
-      }
+      });
     }
-    return result;
   };
+};
 
-  /**
-   * @param {string} template
-   * @return {function(Object):string}
-   */
-  UrlTemplate.prototype.parse = function (template) {
-    var that = this;
-    var operators = ['+', '#', '.', '/', ';', '?', '&'];
-
-    return {
-      expand: function (context) {
-        return template.replace(/\{([^\{\}]+)\}|([^\{\}]+)/g, function (_, expression, literal) {
-          if (expression) {
-            var operator = null,
-                values = [];
-
-            if (operators.indexOf(expression.charAt(0)) !== -1) {
-              operator = expression.charAt(0);
-              expression = expression.substr(1);
-            }
-
-            expression.split(/,/g).forEach(function (variable) {
-              var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-              values.push.apply(values, that.getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
-            });
-
-            if (operator && operator !== '+') {
-              var separator = ',';
-
-              if (operator === '?') {
-                separator = '&';
-              } else if (operator !== '#') {
-                separator = operator;
-              }
-              return (values.length !== 0 ? operator : '') + values.join(separator);
-            } else {
-              return values.join(',');
-            }
-          } else {
-            return that.encodeReserved(literal);
-          }
-        });
-      }
-    };
-  };
-
-  return new UrlTemplate();
-}));
+export default new UrlTemplate();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "devDependencies": {
         "chai": "^4.3.6",
         "mocha": "^9.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
-    "test": "mocha --reporter spec"
+    "test": "node --experimental-json-modules node_modules/mocha/bin/mocha --reporter spec"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "url-template",
   "version": "2.0.8",
-  "decription": "A URI template implementation (RFC 6570 compliant)",
-  "author": "Bram Stein <b.l.stein@gmail.com> (http://www.bramstein.com)",
+  "description": "A URI template implementation (RFC 6570 compliant)",
+  "author": "Bram Stein <b.l.stein@gmail.com> (https://www.bramstein.com)",
   "keywords": [
     "uri-template",
     "uri template",
@@ -21,9 +21,11 @@
     "type": "git",
     "url": "git://github.com/bramstein/url-template.git"
   },
+  "type": "module",
   "main": "./lib/url-template.js",
-  "directories": {
-    "lib": "./lib"
+  "exports": "./lib/url-template.js",
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "scripts": {
     "test": "mocha --reporter spec"

--- a/test/uritemplate-test.js
+++ b/test/uritemplate-test.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
-import { readFile } from 'fs/promises';
 import template from '../lib/url-template.js';
-
-const examples = JSON.parse(await readFile(new URL('../uritemplate-test/spec-examples-by-section.json', import.meta.url)));
+import examples from '../uritemplate-test/spec-examples-by-section.json';
 
 function createTestContext(c) {
   return function (t, r) {

--- a/test/uritemplate-test.js
+++ b/test/uritemplate-test.js
@@ -1,14 +1,8 @@
-var template, expect, examples;
+import { expect } from 'chai';
+import { readFile } from 'fs/promises';
+import template from '../lib/url-template.js';
 
-if (typeof require !== 'undefined') {
-  template = require('../lib/url-template.js');
-  expect = require("chai").expect;
-  examples = require('../uritemplate-test/spec-examples-by-section.json');
-} else {
-  template = window.urltemplate;
-  expect = window.chai.expect;
-  examples = window.examples;
-}
+const examples = JSON.parse(await readFile(new URL('../uritemplate-test/spec-examples-by-section.json', import.meta.url)));
 
 function createTestContext(c) {
   return function (t, r) {

--- a/test/url-template-test.js
+++ b/test/url-template-test.js
@@ -1,12 +1,5 @@
-var template, expect;
-
-if (typeof require !== 'undefined') {
-  template = require('../lib/url-template.js');
-  expect = require("chai").expect;
-} else {
-  template = window.urltemplate;
-  expect = window.chai.expect;
-}
+import { expect } from 'chai';
+import template from '../lib/url-template.js';
 
 function createTestContext(c) {
   return function (t, r) {


### PR DESCRIPTION
Changes the code to use the ECMAScript module syntax instead of CommonJS. This also updates the tests to use the same syntax. More information on pure ESM packages can be found [here](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).

Note that the changes in `url-template.js` look big, but this is simply because the indentation has changed a level, the only real change is the usage of the new module syntax.