### PR TITLE
Extract private methods into scoped functions

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -1,81 +1,41 @@
-/**
- * @constructor
- */
-function UrlTemplate() {
-}
-
-/**
- * @private
- * @param {string} str
- * @return {string}
- */
-UrlTemplate.prototype.encodeReserved = function (str) {
+function encodeReserved(str) {
   return str.split(/(%[0-9A-Fa-f]{2})/g).map(function (part) {
     if (!/%[0-9A-Fa-f]/.test(part)) {
       part = encodeURI(part).replace(/%5B/g, '[').replace(/%5D/g, ']');
     }
     return part;
   }).join('');
-};
+}
 
-/**
- * @private
- * @param {string} str
- * @return {string}
- */
-UrlTemplate.prototype.encodeUnreserved = function (str) {
+function encodeUnreserved(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
     return '%' + c.charCodeAt(0).toString(16).toUpperCase();
   });
 }
 
-/**
- * @private
- * @param {string} operator
- * @param {string} value
- * @param {string} key
- * @return {string}
- */
-UrlTemplate.prototype.encodeValue = function (operator, value, key) {
-  value = (operator === '+' || operator === '#') ? this.encodeReserved(value) : this.encodeUnreserved(value);
+function encodeValue(operator, value, key) {
+  value = (operator === '+' || operator === '#') ? encodeReserved(value) : encodeUnreserved(value);
 
   if (key) {
-    return this.encodeUnreserved(key) + '=' + value;
+    return encodeUnreserved(key) + '=' + value;
   } else {
     return value;
   }
-};
+}
 
-/**
- * @private
- * @param {*} value
- * @return {boolean}
- */
-UrlTemplate.prototype.isDefined = function (value) {
+function isDefined(value) {
   return value !== undefined && value !== null;
-};
+}
 
-/**
- * @private
- * @param {string}
- * @return {boolean}
- */
-UrlTemplate.prototype.isKeyOperator = function (operator) {
+function isKeyOperator(operator) {
   return operator === ';' || operator === '&' || operator === '?';
-};
+}
 
-/**
- * @private
- * @param {Object} context
- * @param {string} operator
- * @param {string} key
- * @param {string} modifier
- */
-UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
+function getValues(context, operator, key, modifier) {
   var value = context[key],
       result = [];
 
-  if (this.isDefined(value) && value !== '') {
+  if (isDefined(value) && value !== '') {
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       value = value.toString();
 
@@ -83,38 +43,38 @@ UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
         value = value.substring(0, parseInt(modifier, 10));
       }
 
-      result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
+      result.push(encodeValue(operator, value, isKeyOperator(operator) ? key : null));
     } else {
       if (modifier === '*') {
         if (Array.isArray(value)) {
-          value.filter(this.isDefined).forEach(function (value) {
-            result.push(this.encodeValue(operator, value, this.isKeyOperator(operator) ? key : null));
-          }, this);
+          value.filter(isDefined).forEach(function (value) {
+            result.push(encodeValue(operator, value, isKeyOperator(operator) ? key : null));
+          });
         } else {
           Object.keys(value).forEach(function (k) {
-            if (this.isDefined(value[k])) {
-              result.push(this.encodeValue(operator, value[k], k));
+            if (isDefined(value[k])) {
+              result.push(encodeValue(operator, value[k], k));
             }
-          }, this);
+          });
         }
       } else {
         var tmp = [];
 
         if (Array.isArray(value)) {
-          value.filter(this.isDefined).forEach(function (value) {
-            tmp.push(this.encodeValue(operator, value));
-          }, this);
+          value.filter(isDefined).forEach(function (value) {
+            tmp.push(encodeValue(operator, value));
+          });
         } else {
           Object.keys(value).forEach(function (k) {
-            if (this.isDefined(value[k])) {
-              tmp.push(this.encodeUnreserved(k));
-              tmp.push(this.encodeValue(operator, value[k].toString()));
+            if (isDefined(value[k])) {
+              tmp.push(encodeUnreserved(k));
+              tmp.push(encodeValue(operator, value[k].toString()));
             }
-          }, this);
+          });
         }
 
-        if (this.isKeyOperator(operator)) {
-          result.push(this.encodeUnreserved(key) + '=' + tmp.join(','));
+        if (isKeyOperator(operator)) {
+          result.push(encodeUnreserved(key) + '=' + tmp.join(','));
         } else if (tmp.length !== 0) {
           result.push(tmp.join(','));
         }
@@ -122,24 +82,29 @@ UrlTemplate.prototype.getValues = function (context, operator, key, modifier) {
     }
   } else {
     if (operator === ';') {
-      if (this.isDefined(value)) {
-        result.push(this.encodeUnreserved(key));
+      if (isDefined(value)) {
+        result.push(encodeUnreserved(key));
       }
     } else if (value === '' && (operator === '&' || operator === '?')) {
-      result.push(this.encodeUnreserved(key) + '=');
+      result.push(encodeUnreserved(key) + '=');
     } else if (value === '') {
       result.push('');
     }
   }
   return result;
-};
+}
+
+/**
+ * @constructor
+ */
+ function UrlTemplate() {
+}
 
 /**
  * @param {string} template
  * @return {function(Object):string}
  */
 UrlTemplate.prototype.parse = function (template) {
-  var that = this;
   var operators = ['+', '#', '.', '/', ';', '?', '&'];
 
   return {
@@ -156,7 +121,7 @@ UrlTemplate.prototype.parse = function (template) {
 
           expression.split(/,/g).forEach(function (variable) {
             var tmp = /([^:\*]*)(?::(\d+)|(\*))?/.exec(variable);
-            values.push.apply(values, that.getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
+            values.push.apply(values, getValues(context, operator, tmp[1], tmp[2] || tmp[3]));
           });
 
           if (operator && operator !== '+') {
@@ -172,7 +137,7 @@ UrlTemplate.prototype.parse = function (template) {
             return values.join(',');
           }
         } else {
-          return that.encodeReserved(literal);
+          return encodeReserved(literal);
         }
       });
     }


### PR DESCRIPTION
Extracts all 'private' methods of `UrlTemplate` into scoped functions to ensure they are actually private. This also reduces the amount of scoping around `this` in the main parse logic and removes the need to alias it to a variable. This decreases the final file size and code complexity in the process.