### PR TITLE
Use a named export for the parse function

### DIFF
--- a/lib/url-template.js
+++ b/lib/url-template.js
@@ -94,17 +94,7 @@ function getValues(context, operator, key, modifier) {
   return result;
 }
 
-/**
- * @constructor
- */
- function UrlTemplate() {
-}
-
-/**
- * @param {string} template
- * @return {function(Object):string}
- */
-UrlTemplate.prototype.parse = function (template) {
+export function parseTemplate(template) {
   var operators = ['+', '#', '.', '/', ';', '?', '&'];
 
   return {
@@ -142,6 +132,4 @@ UrlTemplate.prototype.parse = function (template) {
       });
     }
   };
-};
-
-export default new UrlTemplate();
+}

--- a/test/uritemplate-test.js
+++ b/test/uritemplate-test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
-import template from '../lib/url-template.js';
+import { parseTemplate } from '../lib/url-template.js';
 import examples from '../uritemplate-test/spec-examples-by-section.json';
 
 function createTestContext(c) {
   return function (t, r) {
     if (typeof r === 'string') {
-      expect(template.parse(t).expand(c)).to.eql(r);
+      expect(parseTemplate(t).expand(c)).to.eql(r);
     } else {
-      expect(r.indexOf(template.parse(t).expand(c)) >= 0).to.be.true;
+      expect(r.indexOf(parseTemplate(t).expand(c)) >= 0).to.be.true;
     }
   };
 }

--- a/test/url-template-test.js
+++ b/test/url-template-test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import template from '../lib/url-template.js';
+import { parseTemplate } from '../lib/url-template.js';
 
 function createTestContext(c) {
   return function (t, r) {
-    expect(template.parse(t).expand(c)).to.eql(r);
+    expect(parseTemplate(t).expand(c)).to.eql(r);
   };
 }
 


### PR DESCRIPTION
Replaces the 'class like' default export with a named function called `parseTemplate`. This change reduces code complexity (plus final size) and allows tooling to better optimize (specifically tree-shake) the code in the future if more functionality is added in the future.

I've removed all the JSDoc annotations in the code as they only provide limited type information, a future PR will add proper type definitions for a better experience.

@bramstein since this changes the established API that has been here so far, could you review this code and let me know what you think? Note that the ECMAScript module support will require a major version bump anyways, so this would be the right time to make this change.