### PR TITLE
Change imports of JSON to fix tests

### DIFF
--- a/test/uritemplate-test.js
+++ b/test/uritemplate-test.js
@@ -1,6 +1,10 @@
+import { createRequire } from 'node:module';
+import { fileURLToPath as fromURL } from 'node:url';
 import { expect } from 'chai';
 import { parseTemplate } from '../lib/url-template.js';
-import examples from '../uritemplate-test/spec-examples-by-section.json';
+
+const require = createRequire(fromURL(import.meta.url));
+const examples = require('../uritemplate-test/spec-examples-by-section.json');
 
 function createTestContext(c) {
   return function (t, r) {


### PR DESCRIPTION
Due to a recent change in Node 16 it is now required to add an [import assertion](https://github.com/tc39/proposal-import-assertions) for JSON modules. Because we are not using this new syntax the tests are failing under this version of Node.

Node 12 and 14 do not support this syntax, so instead this PR uses `createRequire()` to include the JSON files the old-school way. Once support for Node 14 is dropped (or support is added) import assertions can be used to replace this code.