### PR TITLE
Remove Node.js 12 from testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Removes Node.js 12 from the testing matrix as this version is no longer supported. Also needed to merge #48.