### PR TITLE
Add type support for array and record values

### DIFF
--- a/lib/url-template.d.ts
+++ b/lib/url-template.d.ts
@@ -1,4 +1,4 @@
-export type PrimitiveValue = string | number | boolean;
+export type PrimitiveValue = string | number | boolean | null;
 
 export interface Template {
   expand(context: Record<string, PrimitiveValue | PrimitiveValue[] | Record<string, PrimitiveValue>>): string;

--- a/lib/url-template.d.ts
+++ b/lib/url-template.d.ts
@@ -1,5 +1,7 @@
+export type PrimitiveValue = string | number | boolean;
+
 export interface Template {
-  expand(context: Record<string, string | number | boolean>): string;
+  expand(context: Record<string, PrimitiveValue | PrimitiveValue[] | Record<string, PrimitiveValue>>): string;
 }
 
 export function parseTemplate(template: string): Template;


### PR DESCRIPTION
Extends the supported types of values that can be passed into the template context. This allows the user to pass in lists of values and key value pairs.

For example:

```javascript
template.expand({
  list: ['a', 'b', 'c'],
  pairs: { foo: 'A', bar: 'B' },
});
```

Closes #55.