### PR TITLE
Allow nested array values for `expand()` in type definition

### DIFF
--- a/lib/url-template.d.ts
+++ b/lib/url-template.d.ts
@@ -1,7 +1,7 @@
 export type PrimitiveValue = string | number | boolean | null;
 
 export interface Template {
-  expand(context: Record<string, PrimitiveValue | PrimitiveValue[] | Record<string, PrimitiveValue>>): string;
+  expand(context: Record<string, PrimitiveValue | PrimitiveValue[] | Record<string, PrimitiveValue | PrimitiveValue[]>>): string;
 }
 
 export function parseTemplate(template: string): Template;


### PR DESCRIPTION
Closes #57