### PR TITLE
Remove caching of `node_modules` on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,15 +23,7 @@ jobs:
           check-latest: true
           cache: npm
 
-      - name: Cache Node modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run tests


### PR DESCRIPTION
Removes the `cache` action that keeps the `node_modules` cached on CI. This doesn't really impact performance, and just means extra maintenance, so removing it should be fine.