### PR TITLE
Drop support for end-of-life Node.js versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [18, 20]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ console.log(emailUrl);
 ## A note on error handling and reporting
 
 The RFC states that errors in the templates could optionally be handled and reported to the user. This implementation takes a slightly different approach in that it tries to do a best effort template expansion and leaves erroneous expressions in the returned URI instead of throwing errors. So for example, the incorrect expression `{unclosed` will return `{unclosed` as output. The leaves incorrect URLs to be handled by your URL library of choice.
+
+## Supported Node.js versions
+
+The same versions that are [actively supported by Node.js](https://github.com/nodejs/release#release-schedule) are also supported by `url-template`, older versions of Node.js might be compatible as well, but are not actively tested against.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "types": "./lib/url-template.d.ts",
   "sideEffects": false,
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   },
   "scripts": {
     "test": "node --experimental-json-modules node_modules/mocha/bin/mocha --reporter spec"


### PR DESCRIPTION
Drops support for [end-of-life](https://github.com/nodejs/release#release-schedule) versions of Node.js, as they are starting to [cause issues](https://github.com/bramstein/url-template/actions/runs/7700828545/job/20985487705?pr=76) running the test-suite. Also clarifies the stance on supporting only actively maintained Node.js versions, making `url-template` an 'evergreen' package (new Node.js version requirements not considered a breaking change).

I will of course strive to keep things backwards-compatible regardless, this simply removes the maintenance burden of supporting these Node.js versions and their ever growing variations.